### PR TITLE
Restructure JavaScript files to avoid modules; add more fetch functions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,14 +6,25 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 
+		<!-- Load both our CSS file and the one for OpenLayers. -->
 		<link rel="stylesheet" href="/stylesheets/style.css" />
 		<link rel="stylesheet" href="/ol/ol.css" />
 
+		<!-- Before any other scripts, load jQuery. -->
 		<script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
-		<script defer type="module" src="/javascripts/main.js"></script>
-		<script
-	src="/javascripts/hamburger.js">
-</script>
+
+		<!--
+			OpenLayers uses modules, but we want to avoid using those in the
+			rest of our code. However, since module and non-module code can't
+			be mixed, we import all the modules we need from OpenLayers into
+			the global namespace.
+		-->
+		<script defer type="module" src="/javascripts/importModules.js"></script>
+
+		<!-- Then, we can commence loading our scripts in order of usage. -->
+		<script defer src="/javascripts/fetch.js"></script>
+		<script defer src="/javascripts/map.js"></script>
+		<script defer src="/javascripts/interaction.js"></script>
 	</head>
 	<body>
 		<section class="top-bar">
@@ -33,7 +44,7 @@
 					<li><a href="#">Service Alerts</a></li>
 					<li><a href="#">About</a></li>
 				</ul>
-				</nav> 
+				</nav>
 			</div>
 			<div class="menu-bg" id="menu-bg"></div>
 		</div>

--- a/public/javascripts/fetch.js
+++ b/public/javascripts/fetch.js
@@ -1,21 +1,49 @@
-export const APP_ID = "DB9C2B0467902CB970AD9CD6B";
+"use strict";
+
+// The app ID for accessing the live TriMet APIs. There's no point in hiding
+// this constant since it's placed directly in the GET query string, and
+// therefore is available for anyone to see.
+const APP_ID = "DB9C2B0467902CB970AD9CD6B";
 
 /**
- * Fetches a text file from an external URL, calling functions for success or
- * error.
+ * Given a base URL and a set of key-value pairs, returns a new URL made of the
+ * base URL and a query string containing the app ID and the provided key-value
+ * pairs. This results in a URL suitable for accessing live TriMet data.
+ *
+ * @param url    The URL to add the query string to. It must not already have a
+ *               query string.
+ * @param params (optional) The set of key-value pairs to add to the query
+ *               string besides the app ID. If omitted, no other params are
+ *               attached.
+ * @return The new URL.
+ */
+function makeAppUrl(url, params) {
+	const fullParams = Object.assign({}, {appID: APP_ID}, params);
+	return url + "?" + $.param(fullParams);
+}
+
+/**
+ * Fetches a file from an external URL, calling functions for success or error.
+ * The data can be interpreted as either text or JSON.
+ *
+ * Also see fetchText() and fetchJson() for function alternatives with simpler
+ * call signatures.
  *
  * @param url       The URL to fetch the text file from.
- * @param onSuccess The function to call on success. The fetched string will be
- *                  passed as the sole argument.
+ * @param dataType  Determines how to interpret the fetched data. Can be either
+ *                  "text" for a string, "json" for a JavaScript object, or
+ *                  "xml" for a XML document tree.
+ * @param onSuccess The function to call on success. The fetched string/object
+ *                  will be passed as the sole argument.
  * @param onError   The function to call on error. The error status will be
  *                  passed as the sole argument.
  */
-export function fetchText(url, onSuccess, onError) {
+function fetchData(url, dataType, onSuccess, onError) {
 	$.ajax({
 		// Fetch the URL as a raw text file with a two second timeout to avoid
 		// waiting forever.
 		url: url,
-		dataType: "text",
+		dataType: dataType,
 		timeout: 2000,
 
 		// On success, pass the text directly to the success handler.
@@ -30,4 +58,44 @@ export function fetchText(url, onSuccess, onError) {
 			onError(`Fetch "${url}" (${textStatus}) ${statusCode}`);
 		},
 	});
+}
+
+/**
+ * Fetches text from an external URL. It is identical to fetchData() with a
+ * dataType of "text".
+ */
+function fetchText(url, onSuccess, onError) {
+	return fetchData(url, "text", onSuccess, onError);
+}
+
+/**
+ * Fetches JSON from an external URL. It is identical to fetchData() with a
+ * dataType of "text".
+ */
+function fetchJson(url, onSuccess, onError) {
+	return fetchData(url, "json", onSuccess, onError);
+}
+
+/**
+ * Fetches XML from an external URL. It is identical to fetchData() with a
+ * dataType of "xml".
+ */
+function fetchXml(url, onSuccess, onError) {
+	return fetchData(url, "xml", onSuccess, onError);
+}
+
+/**
+ * Fetches JSON from a TriMet live data service. It is identical to fetchJson()
+ * with a url of `makeAppUrl(url, params)`.
+ */
+function fetchAppJson(url, params, onSuccess, onError) {
+	return fetchJson(makeAppUrl(url, params), onSuccess, onError);
+}
+
+/**
+ * Fetches XML from a TriMet live data service. It is identical to fetchXml()
+ * with a url of `makeAppUrl(url, params)`.
+ */
+function fetchAppXml(url, params, onSuccess, onError) {
+	return fetchJson(makeAppUrl(url, params), onSuccess, onError);
 }

--- a/public/javascripts/importModules.js
+++ b/public/javascripts/importModules.js
@@ -1,0 +1,23 @@
+// Frankly, this is hacky. It would be nice if we could import in a nicely
+// structured manner, but it doesn't seem to be possible given the way
+// OpenLayers is structured.
+import Map from "/ol/Map.js";
+import View from "/ol/View.js";
+import TileLayer from "/ol/layer/Tile.js";
+import * as proj from "/ol/proj.js";
+import XYZ from "/ol/source/XYZ.js";
+
+// To make the ol variable global, we can't use the var keyword since this is a
+// module file. Instead, we manually put it into the window, which is where
+// global variables actually reside. Then it becomes accessible everywhere.
+window.ol = {}
+ol.Map = Map
+ol.View = View
+
+ol.layer = {}
+ol.layer.TileLayer = TileLayer
+
+ol.proj = proj
+
+ol.source = {}
+ol.source.XYZ = XYZ

--- a/public/javascripts/interaction.js
+++ b/public/javascripts/interaction.js
@@ -1,6 +1,8 @@
+"use strict";
+
 /*code courtesy of https://alvarotrigo.com/blog/hamburger-menu-css/*/
 function menuOnClick() {
 	document.getElementById("menu-bar").classList.toggle("change");
 	document.getElementById("nav").classList.toggle("change");
 	document.getElementById("menu-bg").classList.toggle("change-bg");
-  }
+}

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,2 +1,0 @@
-import "./map.js";
-import * as fetch from "./fetch.js";

--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -1,20 +1,16 @@
-import Map from "/ol/Map.js";
-import XYZ from "/ol/source/XYZ.js";
-import TileLayer from "/ol/layer/Tile.js";
-import View from "/ol/View.js";
-import {fromLonLat} from "/ol/proj.js";
+"use strict";
 
-const map = new Map({
+var map = new ol.Map({
 	target: "map",
 	layers: [
-		new TileLayer({
-			source: new XYZ({
+		new ol.layer.TileLayer({
+			source: new ol.source.XYZ({
 				url: "https://tiles.trimet.org/styles/trimet/{z}/{x}/{y}.png"
 			}),
 		}),
 	],
-	view: new View({
-		center: fromLonLat([-122.676483, 45.523064]),
+	view: new ol.View({
+		center: ol.proj.fromLonLat([-122.676483, 45.523064]),
 		zoom: 10,
 	}),
 });


### PR DESCRIPTION
Modules are really restrictive and a pain, so I restructured things to avoid them. It's a little clunky since we have to manually put all OpenLayers imports into the global namespace, but it's better than any alternatives I could find.

I renamed the JavaScript files accordingly:
* `importModules.js`: The file manually putting OpenLayers imports into the global namespace. Edit this if you need any other OpenLayers imports anywhere in the app.
* `fetch.js`: Fetch functions. I also expanded these functions for ease of use--now there's also a `fetchJson()` for JSON files and `fetchAppJson()` for live data that requires an app ID; there are also XML variants thereof.
* `map.js`: Anything having to do with the map itself.
* `interaction.js`: Formerly `hamburger.js`; however, this file should be used for any dynamic interaction with the page--opening and closing sidebars, popups, etc.

More files may be added later as our app grows, but these are the ones I found important for now.

You'll also note the `"use strict";` at the top of all the JavaScript files except for `importModules.js` (where it it's enabled by default). This turns on strict mode JavaScript, which removes some of the awful, terrible, disgusting things that JavaScript does by default. (Many other disgusting things are still around, but that turns off the most egregious ones.) So, this should be at the top of every script file loaded in `index.html`.
