### PR TITLE
Fix oversights from refactor; replace bad fetching scheme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,10 +19,11 @@
 			crossorigin=""></script>
 
 		<!-- Then, we can commence loading our scripts in order of usage.
-			First, we load the scripts that contain utility functions but don't
-			do any fetching or DOM modification. -->
+			First, we load the scripts with important utilities that most other
+			scripts depend on. -->
 		<script defer src="/javascripts/util.js"></script>
 		<script defer src="/javascripts/fetch.js"></script>
+		<script defer src="/javascripts/dataManager.js"></script>
 		<script defer src="/javascripts/uiHelpers.js"></script>
 
 		<!-- Finally, load the files that handle the DOM and map. -->
@@ -36,8 +37,14 @@
 			like dialogs, and hidden content are stored outside of the main
 			grid.  -->
 		<main>
-			<!-- Space for holding the map. -->
-			<div id="map"></div>
+			<!-- Sidebar selector containing buttons for choosing what to
+				display in the sidebar, controlled by a TabList. -->
+			<div id="selector-bg"></div>
+			<nav id="selector" data-tablist="sidebar">
+				<button class="special">Tracker</button>
+				<button class="special">Stops</button>
+				<button class="special" data-tab="routes">Routes</button>
+			</nav>
 
 			<!-- Top bar containing the title of the application and buttons
 				for pop-ups. -->
@@ -51,36 +58,31 @@
 				</nav>
 			</header>
 
-			<!-- Sidebar selector containing buttons for choosing what to
-				display in the sidebar, controlled by a TabList. -->
-			<div id="selector-bg"></div>
-			<nav id="selector" data-tablist="sidebar">
-				<button class="special">Tracker</button>
-				<button class="special">Stops</button>
-				<button class="special" data-tab="routes">Routes</button>
-			</nav>
-
 			<!-- The sidebar; this is controlled by the same TabList as the
 				sidebar selector. -->
 			<div id="sidebar" data-tablist="sidebar">
-				<div id="routes-sidebar" data-tab="routes">
-					<div id="routes-loading-box" data-shown>
-						<div class="loading">Loading routes...</div>
-					</div>
-					<div id="routes-list-box">
-						<div id="routes-list-header">
+				<!-- Routes sidebar; contains subpages for routes and stops for
+					each route in both directions. -->
+				<div id="routes-sidebar" data-tab="routes" data-tablist="routes-pages">
+					<!-- Routes subpage for showing the list of routes. -->
+					<div data-tab="routes">
+						<div id="routes-header">
 							<input id="routes-search" type="search" placeholder="Search for route" />
+							<button id="routes-clear-search" class="special light-button">&#xD7;</button>
 						</div>
 						<div id="routes-list">
-							<button>Route</button>
+							<div class="loading">Loading routes...</div>
 						</div>
 					</div>
-					<div id="dir-box">
+
+					<!-- Routes subpage for showing the list of stops in a
+						route in both directions. -->
+					<div data-tab="dirs">
 						<div id="dir-header">
 							<button id="dir-back" class="special light-button">&#x2190;</button>
 							<div id="dir-chosen"></div>
 						</div>
-						<div id="dir-selector" data-tablist="routes-dir">
+						<div class="selector" data-tablist="routes-dir">
 							<button id="dir-0-selector" class="special" data-tab="dir-0"></button>
 							<button id="dir-1-selector" class="special" data-tab="dir-1"></button>
 						</div>
@@ -91,6 +93,9 @@
 					</div>
 				</div>
 			</div>
+
+			<!-- Space for holding the map. -->
+			<div id="map"></div>
 		</main>
 
 		<!-- The container for holding modal dialog boxes. It will only be
@@ -165,7 +170,7 @@
 			</div>
 		</template>
 
-		<!-- The initial "loading" message bar shown while static data is being
+		<!-- The initial loading message bar shown while static data is being
 			fetched. -->
 		<template id="tem-loading-message">
 			Loading data... <span class="loading" style="width: 400px"></span>

--- a/public/javascripts/dataManager.js
+++ b/public/javascripts/dataManager.js
@@ -1,0 +1,148 @@
+/**
+ * A class that manages fetching data once and over intervals of time.
+ *
+ * The primary way to use this class is to register data to be fetched and
+ * callbacks to run when that data has been fetched. For instance, this
+ * instructs a fetcher to fetch routes from a specific URL and place it in the
+ * field named "routeStops":
+ *
+ *     staticFetch.addData("routeStops",
+ *         () => fetchAppXml("https://developer.trimet.org/ws/V1/routeConfig", {
+ *             stops: true,
+ *             dir: true,
+ *         })
+ *     );
+ *
+ * To retrieve this field later from `staticFetch`, simply use:
+ *
+ *     staticFetch.data.routeStops
+ *
+ * When the data is fetched, the manager will run all callbacks associated with
+ * it. Depending on the manager, it may repeatedly fetch data, in which case
+ * the callbacks are called each time. To register a callback:
+ *
+ *     staticFetch.onFetch(data => {
+ *         // `data` is a shortcut to `staticFetch.data` here.
+ *         console.log(data.routeStops);
+ *     });
+ *
+ * There are three standard FetchManagers: `staticFetch`, `slowFetch`, and
+ * `fastFetch`. Refer to their documentation for details.
+ *
+ * @prop data   The current data loaded from the fetches registered with
+ *              addData(). Each field will be null until the first fetch.
+ * @prop loaded A member that is true iff data has been fetched at least once.
+ */
+class FetchManager {
+	/**
+	 * Construct a new FetchManager for which callbacks can be registered. The
+	 * FetchManager will begin fetching data when the jQuery
+	 * `$(document).ready()` function is fired, i.e. after all JavaScript files
+	 * have loaded.
+	 *
+	 * @param interval (optional) If non-zero, the data will be fetched
+	 *                 repeatedly over this interval of time. Defaults to zero.
+	 */
+	constructor(interval = 0) {
+		this.data = {};
+		this.loaded = false;
+
+		this.names = [];
+		this.producers = [];
+		this.callbacks = [];
+
+		// After the JavaScript files have loaded, start running the fetches,
+		// either once or over an interval, depending on the parameter.
+		$(document).ready(() => {
+			if (interval === 0) {
+				this.runOnce();
+			} else {
+				this.runLoop(interval);
+			}
+		});
+	}
+
+	/**
+	 * Registers a new data field to be fetched by the given producer function
+	 * that returns fetch promises.
+	 *
+	 * @param key      The field to store the fetched data in.
+	 * @param producer A function that takes no arguments and returns a new
+	 *                 fetch promise when called.
+	 */
+	addData(key, producer) {
+		this.data[key] = null;
+
+		this.names.push(key);
+		this.producers.push(producer);
+	}
+
+	/**
+	 * Registers a new callback to be called whenever all registered data has
+	 * finished fetching. If data is fetched over an interval, this is called
+	 * every time the data finishes fetching.
+	 *
+	 * @param callback The function to be called on fetch. A reference to the
+	 *                 `data` property will be passed to the callback.
+	 */
+	onFetch(callback) {
+		this.callbacks.push(callback);
+	}
+
+	/**
+	 * Internal method: Asynchronously starts a new fetch from all producers,
+	 * sets these into their respective fields in `data`, and calls all
+	 * callbacks.
+	 */
+	async runOnce() {
+		// Call all the fetch producers and simultaneously wait for each of the
+		// promises they resolve to.
+		let promises = this.producers.map(p => p());
+		let resolved = await Promise.all(promises);
+
+		// Set the resolved data into the appropiate fields in `data`.
+		for (let i = 0; i < this.names.length; i++) {
+			this.data[this.names[i]] = resolved[i];
+		}
+
+		// The data has now been loaded for at least the first time, so set the
+		// `loaded` property to true.
+		this.loaded = true;
+
+		// Call all registered fetch callbacks.
+		this.callbacks.forEach(c => c(this.data));
+	}
+
+	/**
+	 * Internal method: Loops infinitely, calling runOnce() and waiting the
+	 * specified interval of time after it completes before calling it again.
+	 *
+	 * @param interval The interval of time to wait between fetches.
+	 */
+	async runLoop(interval) {
+		while (true) {
+			await this.runOnce();
+			await delay(interval);
+		}
+	}
+}
+
+/**
+ * FetchManager that fetches static data only once while the page is loading.
+ * This is primarily data that hardly ever changes, such as bus routes.
+ */
+let staticFetch = new FetchManager();
+
+/**
+ * FetchManager that slowly but repeatedly fetches data every five minutes.
+ * This should be used for data that can change while the app is running, but
+ * only infrequently, such as service alerts.
+ */
+let slowFetch = new FetchManager(1000 * 60 * 5);
+
+/**
+ * FetchManager that quickly and repeatedly fetches data about every three
+ * seconds, depending on network speed. This should be used for data that needs
+ * to be updated while the user is using the page, such as bus locations.
+ */
+let fastFetch = new FetchManager(1000 * 3);

--- a/public/javascripts/fetch.js
+++ b/public/javascripts/fetch.js
@@ -24,233 +24,153 @@ var APP_ID = "DB9C2B0467902CB970AD9CD6B";
  * @return The new URL.
  */
 function makeAppUrl(url, params) {
-	const fullParams = Object.assign({}, {appID: APP_ID}, params);
+	const fullParams = Object.assign({appID: APP_ID}, params);
 	return url + "?" + $.param(fullParams);
 }
 
-/**
- * Defines an error that can be thrown from or returned in the error callback
- * for fetchData() and associated functions.
- *
- * @prop url     The URL that caused the error.
- * @prop message A summary of the fetching/HTTP error and/or parsing error.
- */
-class FetchError extends Error {
-	constructor(url, message) {
-		super(`${url}: ${message}`);
+/** Time in seconds defining how long fetchData() will wait after a failed
+ * fetch before trying again. Defined as two seconds. */
+var RETRY_FETCH = 1000 * 2;
 
-		this.name = "FetchError";
-		this.url = url;
-	}
-}
+/** Time in seconds before a fetch will timeout. Defined as ten seconds because
+ * anything longer than that will result in an unusably slow fetch. */
+var FETCH_TIMEOUT = 1000 * 10;
+
+/** Function hook that is called by `fetchData()` on successful fetch. */
+var onFetchSuccess = () => {};
+/** Function hook that is called by `fetchData()` each time on failure. */
+var onFetchFailure = (err) => {};
 
 /**
- * Defines an error that occurs when a fetch times out.
+ * Fetches a file from an external URL and returns a promise, parsing the data
+ * as text, JSON, or XML. Optionally, if the fetch fails or times out, this
+ * function can wait and retry the fetch again until the fetch succeeds.
  *
- * @prop url     The URL that timed out.
- * @prop message A simple message explaining that the connection timed out.
- */
-class TimeoutError extends FetchError {
-	constructor(url) {
-		super(url, `${url}: Request timed out`);
-
-		this.name = "TimeoutError";
-		this.url = url;
-	}
-}
-
-/**
- * Fetches a file from an external URL and returns a promise. Alternatively,
- * callback function for success and error can be used instead of the promise.
- * If these are provided, the promise will never resolve or reject.
+ * See fetchText(), fetchJson(), and fetchXml() for function alternatives with
+ * simpler call signatures. Also see fetchAppJson() and fetchAppXml() for
+ * variants that use makeAppUrl().
  *
- * The data can be interpreted as text, JSON, or XML.
- *
- * Also see fetchText(), fetchJson(), and fetchXml() for function alternatives
- * with simpler call signatures.
- *
- * @param url       The URL to fetch the text file from.
+ * @param url       The URL to fetch the data from.
  * @param dataType  Determines how to interpret the fetched data. Can be either
  *                  "text" for a string, "json" for a JavaScript object, or
- *                  "xml" for a XML document tree.
- * @param onSuccess (optional) The function to call on success. The fetched
- *                  string/object will be passed as the sole argument.
- * @param onError   (optional) The function to call on error. The exception
- *                  will be passed as the sole argument.
- *
- * @throws FetchError or TimeoutError if the promise rejected. No errors are
- *         thrown if callbacks are used.
+ *                  "xml" for an XML document tree.
+ * @param retry     (optional) If true, the fetch will be retried on error
+ *                  until success. If false, an error object is thrown.
+ *                  Defaults to true.
+ * @return A promise that resolves to the data being fetched. If the fetch can
+ *         never succeed, the function will never return.
+ * @throws If `retry` is false and the fetch fails, an object containing two
+ *         string values, `category` and `code` for jQuery category and HTTP
+ *         status respectively, will be thrown.
  */
-function fetchData(url, dataType, onSuccess, onError) {
+async function fetchData(url, dataType, retry = true) {
+	// Enter an indefinite loop to repeatedly attempt to fetch the data until
+	// we succeed.
+	while (true) {
+		try {
+			// Asynchronously await the actual fetch using a promise wrapper
+			// around jQuery's callback-based AJAX API
+			let data = await fetchPromise(url, dataType);
+
+			// If we succeeded without throwing an error, call the success hook
+			// and return the data.
+			onFetchSuccess();
+			return data;
+		} catch (err) {
+			// If the fetch failed and the promise rejected, catch that error
+			// and handle it. Regardless of whether we retry the fetch or not,
+			// display the error message bar.
+			onFetchFailure(err);
+
+			if (retry) {
+				// If we want to retry the fetch, just log a warning about the
+				// failed fetch and continue on.
+				console.warn(`fetchData("${url}", "${dataType}"): ` +
+					`(${err.category}) ${err.code}`);
+			} else {
+				// If we don't want to retry, just propagate the error.
+				throw err;
+			}
+		}
+
+		// If we reach this point in the code, we are retrying after a failed
+		// fetch. Wait for a bit before repeating the loop.
+		await delay(RETRY_FETCH);
+	}
+}
+
+/**
+ * Internal helper function for fetchData(); calls jQuery's AJAX API with the
+ * specified URL and data type and returns a promise that will resolve or
+ * reject based on the result of that call.
+ *
+ * @param url      The URL to fetch the data from.
+ * @param dataType The data type to instruct jQuery to interpret the data as.
+ * @return A promise that will resolve when jQuery's AJAX callbacks run.
+ */
+function fetchPromise(url, dataType) {
 	return new Promise((resolve, reject) => {
 		$.ajax({
-			// Fetch the URL as a raw text file with a two second timeout to
-			// avoid waiting forever.
+			// Provide the URL and data type verbatim. We also provide
+			// a timeout so the fetch doesn't try to resolve for
+			// inordinately long amounts of time.
 			url: url,
 			dataType: dataType,
-			timeout: 2000,
+			timeout: FETCH_TIMEOUT,
 
-			// On success, pass the text directly to the success handler.
+			// On success, simply resolve the promise.
 			success: (data, statusCode, xhr) => {
-				if (onSuccess) {
-					onSuccess(data);
-				} else {
-					resolve(data);
-				}
+				resolve(data);
 			},
 
-			// On error, call the error handler with error information combined
-			// into a single string, namely the URL, status summary, and status
-			// code.
+			// On error, reject the promise with an error message
+			// object containing information about the error.
 			error: (xhr, category, code) => {
-				code = code || "unknown";
-
-				let error;
-				if (category === "timeout") {
-					error = new TimeoutError(url);
-				} else {
-					error = new FetchError(url, `(${category}) ${code}`);
-				}
-
-				if (onError) {
-					onError(error);
-				} else {
-					reject(error);
-				}
+				reject({
+					category: category,
+					code: code || "unknown",
+				});
 			},
 		});
-	});
+	})
 }
 
 /**
  * Fetches text from an external URL. It is identical to fetchData() with a
  * dataType of "text".
  */
-function fetchText(url, onSuccess, onError) {
-	return fetchData(url, "text", onSuccess, onError);
+function fetchText(url, retry) {
+	return fetchData(url, "text", retry);
 }
 
 /**
  * Fetches JSON from an external URL. It is identical to fetchData() with a
  * dataType of "text".
  */
-function fetchJson(url, onSuccess, onError) {
-	return fetchData(url, "json", onSuccess, onError);
+function fetchJson(url, retry) {
+	return fetchData(url, "json", retry);
 }
 
 /**
  * Fetches XML from an external URL. It is identical to fetchData() with a
  * dataType of "xml".
  */
-function fetchXml(url, onSuccess, onError) {
-	return fetchData(url, "xml", onSuccess, onError);
-}
-
-/**
- * Fetches JSON from a TriMet live data service. It is identical to fetchData()
- * with a url of `makeAppUrl(url, params)`.
- */
-function fetchAppData(url, params, type, onSuccess, onError) {
-	return fetchData(makeAppUrl(url, params), type, onSuccess, onError);
+function fetchXml(url, retry) {
+	return fetchData(url, "xml", retry);
 }
 
 /**
  * Fetches JSON from a TriMet live data service. It is identical to fetchJson()
  * with a url of `makeAppUrl(url, params)`.
  */
-function fetchAppJson(url, params, onSuccess, onError) {
-	return fetchJson(makeAppUrl(url, params), onSuccess, onError);
+function fetchAppJson(url, params, retry) {
+	return fetchJson(makeAppUrl(url, params), retry);
 }
 
 /**
  * Fetches XML from a TriMet live data service. It is identical to fetchXml()
  * with a url of `makeAppUrl(url, params)`.
  */
-function fetchAppXml(url, params, onSuccess, onError) {
-	return fetchXml(makeAppUrl(url, params), onSuccess, onError);
-}
-
-var RETRY_FETCH = 1000 * 2;
-var FAST_FETCH = 1000;
-var SLOW_FETCH = 1000 * 60;
-
-class Fetcher {
-	constructor(fetcher) {
-		this.fetcher = fetcher;
-		this.value = null;
-
-		this.pendingTimeout = null;
-
-		this.firstEvent = true;
-		this.events = {
-			first: [],
-			fetch: []
-		};
-	}
-
-	on(name, event) {
-		this.events[name].push(event);
-		return this;
-	}
-
-	single() {
-		this.cancel();
-		this._queueFetch(0, -1, true);
-		return this;
-	}
-
-	interval(time) {
-		this.cancel();
-		this._queueFetch(0, time, true);
-		return this;
-	}
-
-	cancel() {
-		if (this.pendingTimeout !== null) {
-			window.clearTimeout(this.pendingTimeout);
-			this.pendingTimeout = null;
-		}
-	}
-
-	async _callFetcher(interval) {
-		try {
-			this.value = await this.fetcher();
-
-			if (this.firstEvent) {
-				this._callEvents("first");
-				this.firstEvent = false;
-			}
-			this._callEvents("fetch");
-
-			if (interval >= 0) {
-				this._queueFetch(interval, interval);
-			} else {
-				this.pendingTimeout = null;
-			}
-		} catch (err) {
-			if (err instanceof FetchError) {
-				// TODO: Display message bar with error
-			} else {
-				throw err;
-			}
-
-			console.warn(err.message);
-
-			this._queueFetch(RETRY_FETCH, interval);
-		}
-	}
-
-	_queueFetch(wait, interval, force = false) {
-		if (force || this.pendingTimeout !== null) {
-			this.pendingTimeout = window.setTimeout(() => {
-				this._callFetcher(interval);
-			}, wait);
-		}
-	}
-
-	_callEvents(name) {
-		for (event of this.events[name]) {
-			event(this.value);
-		}
-	}
+function fetchAppXml(url, params, retry) {
+	return fetchXml(makeAppUrl(url, params), retry);
 }

--- a/public/javascripts/interaction.js
+++ b/public/javascripts/interaction.js
@@ -9,10 +9,6 @@ $("#info-how-to").on("click", e => {
 		.show();
 });
 
-$("#info-service-alerts").on("click", e => {
-	printAlertsTable();
-});
-
 $("#info-about").on("click", e => {
 	new Dialog("About")
 		.add($template("tem-about"))
@@ -22,5 +18,32 @@ $("#info-about").on("click", e => {
 
 // Make our tab controller for the sidebar tabs.
 var sidebarTabs = new TabList("sidebar")
-	.bindButtons()
-	.openTab("routes");
+	.showTab("routes");
+
+// Make a loading message that we hide once the static data is loaded.
+var loadingMessage = new Message()
+	.add($template("tem-loading-message"))
+	.show();
+
+staticFetch.onFetch(data => {
+	loadingMessage.hide();
+});
+
+// Hook into the `fetchData()` function to show a message bar on failure.
+var fetchMessage = new Message()
+	.button("Retry", undefined, false);
+
+onFetchSuccess = function() {
+	// On successful fetch, hide the message.
+	fetchMessage.hide();
+}
+
+onFetchFailure = function(err) {
+	// On a fetch that failed, change the message's text to a descriptive error
+	// message and show it.
+	let messageText = err.category === "timeout" ?
+		"Fetching data from the server took too long." :
+		"Unable to establish connection to the server.";
+
+	fetchMessage.clear().text(messageText).show();
+}

--- a/public/javascripts/table.js
+++ b/public/javascripts/table.js
@@ -1,24 +1,45 @@
 "use strict";
 
-var dirsTabs = new TabList("routes-dir")
-	.bindButtons()
+// Create a non-user interactable tab list for the routes sidebar: one page for
+// the routes list, and one page for the directions.
+var routePages = new TabList("routes-pages", false)
+	.showTab("routes");
 
-function showRoutesBox(sel) {
-	$("#routes-sidebar > *").removeAttr("data-shown");
-	$(sel).attr("data-shown", true);
-}
+// Create a tab list for the inbound and outbound direction tabs.
+var dirsTabs = new TabList("routes-dir");
 
+/**
+ * Updates the list of stops in each direction displayed in the sidebar in
+ * accord with a certain route.
+ *
+ * @param routeNode The XML node from the routeStops XML for the directions and
+ *                  stops to display.
+ */
 function updateDirs(routeNode) {
-	dirsTabs.openTab("dir-0");
+	// When we show directions, always show the first tab.
+	dirsTabs.showTab("dir-0");
+
+	// It's possible for a route to only have one direction, so hide both tabs
+	// and empty their contents for now.
+	$("#dir-0-selector, #dir-1-selector").hide().text("");
+	$("#dir-0-list, #dir-1-list").empty();
+
+	// Update the text for the route we chose.
 	$("#dir-chosen").text(routeNode.getAttribute("desc"));
 
+	// Loop over the directions we have as children, which may be one or two.
 	for (let dirNode of routeNode.children) {
 		let dir = dirNode.getAttribute("dir");
 
-		$("#dir-" + dir + "-selector").text(dirNode.getAttribute("desc"));
-		let dirElem = $("#dir-" + dir + "-list");
-		dirElem.scrollTop(0);
+		// Reshow the selector for this direction and give it the right label.
+		$("#dir-" + dir + "-selector")
+			.show()
+			.text(dirNode.getAttribute("desc"));
 
+		// Get the list for this direction.
+		let dirElem = $("#dir-" + dir + "-list").scrollTop(0);
+
+		// Add all the stops that this direction has to the list.
 		for (let stopNode of dirNode.children) {
 			let buttonElem = $("<button>").text(stopNode.getAttribute("desc"));
 			dirElem.append(buttonElem);
@@ -26,14 +47,26 @@ function updateDirs(routeNode) {
 	}
 }
 
+/**
+ * Updates which route buttons are shown or hidden based on the current search
+ * terms that are listed in the search bar.
+ */
 function updateRouteSearch() {
 	let routesElem = $("#routes-list");
+
+	// Get our search term with case insensitivity and ignoring leading or
+	// trailing whitespace.
 	let searchTerm = $("#routes-search").val().trim().toLowerCase();
 
+	// Loop over all the buttons in our routes and decide which ones to show
+	// and hide.
 	for (let buttonElem of routesElem.children()) {
+		// Get the button route name, also case insensitive.
 		buttonElem = $(buttonElem);
 		let routeName = buttonElem.text().toLowerCase();
 
+		// If the button's route name includes the search term, show this
+		// button in case it was hidden before. Otherwise, hide this button.
 		if (routeName.includes(searchTerm)) {
 			buttonElem.show();
 		} else {
@@ -42,39 +75,70 @@ function updateRouteSearch() {
 	}
 }
 
-function updateRoutes(xml) {
+/**
+ * Updates the list of routes displayed in the sidebar in accord with the
+ * routeStops XML file fetched from TriMet's servers.
+ */
+function updateRoutes() {
+	let xml = staticFetch.data.routeStops;
+
+	// Get and clear out our current list of routes.
 	let routesElem = $("#routes-list").empty();
 
+	// Loop over all the route children of the root of the XML document and add
+	// buttons for each of them.
 	for (let routeNode of xml.documentElement.children) {
 		let buttonElem = $("<button>")
 			.text(routeNode.getAttribute("desc"))
-			.on("click", (e) => {
-				showRoutesBox("#dir-box");
+			.on("click", e => {
+				// When the button is clicked, show the stops for that route.
+				routePages.showTab("dirs");
 				updateDirs(routeNode);
 			});
 
 		routesElem.append(buttonElem);
 	}
 
+	// Since the list of buttons was changed, also re-update which ones are
+	// shown due to the search bar.
 	updateRouteSearch();
 }
 
-$("#routes-search").on("input", (e) => {
+// When the search bar is edited, update the list of routes.
+$("#routes-search").on("input", e => {
 	updateRouteSearch();
 });
 
-$("#dir-back").on("click", (e) => {
-	showRoutesBox("#routes-list-box");
+// Clear and refocus the search field when clicking the X button, and update
+// the list of routes.
+$("#routes-clear-search").on("click", e => {
+	$("#routes-search").val("").focus();
+	updateRouteSearch();
 });
 
-new Fetcher(() => {
-		return fetchAppXml(
-			"https://developer.trimet.org/ws/V1/routeConfig",
-			{stops: true, dir: true}
-		);
+// Go back to the list of routes when the user clicks the back button.
+$("#dir-back").on("click", e => {
+	routePages.showTab("routes");
+});
+
+// When the direction tabs are clicked, scroll the lists back to the top.
+$("#dir-0-selector, #dir-1-selector").on("click", e => {
+	$("#dir-0-list, #dir-1-list").scrollTop(0);
+});
+
+/* Fetch our list of routes with stops for the table as a static fetch. It's
+ * possible, although highly improbably, for routes to change while the user is
+ * using the app; however, it's too unlikely to bother about, so a page refresh
+ * is required to see new routes.
+ */
+staticFetch.addData("routeStops",
+	() => fetchAppXml("https://developer.trimet.org/ws/V1/routeConfig", {
+		stops: true,
+		dir: true,
 	})
-	.on("first", (data) => {
-		showRoutesBox("#routes-list-box");
-	})
-	.on("fetch", updateRoutes)
-	.interval(SLOW_FETCH);
+);
+
+// Once we have our static data, update the routes in the table.
+staticFetch.onFetch(data => {
+	updateRoutes();
+});

--- a/public/javascripts/util.js
+++ b/public/javascripts/util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * Checks whether a condition is true and throws an error if not.
  *
@@ -18,4 +20,30 @@ function assert(cond, message = "assert() called") {
  */
 function fail(message = "fail() called") {
 	throw new Error(message);
+}
+
+/**
+ * Alternative to window.setTimeout() that uses promises, making it ideal for
+ * use in asynchronous functions. For example:
+ *
+ *     async function myFunc() {
+ *         // Do some stuff
+ *
+ *         // Wait for two seconds
+ *         await delay(2000);
+ *
+ *         // Do some more stuff
+ *     }
+ *
+ * @param time  The time in milliseconds to delay for. Defaults to 0, in which
+ *              case the promise will resolve on the next event cycle.
+ * @param value (optional) The value that the promise will resolve to. If not
+ *              provided, the promise will resolve to undefined.
+ * @return A promise that will resolve to the specified value after the given
+ *         amount of time.
+ */
+function delay(time = 0, value) {
+	return new Promise((resolve, reject) => {
+		window.setTimeout(resolve, time, value);
+	});
 }

--- a/public/stylesheets/controls.css
+++ b/public/stylesheets/controls.css
@@ -110,3 +110,50 @@ span.loading {
 		background-position: 0;
 	}
 }
+
+.light-button {
+	padding: 2px 7px;
+	border: 1px solid transparent;
+	border-radius: 3px;
+
+	background-color: var(--accent-bg);
+	color: var(--accent-fg);
+
+	cursor: pointer;
+}
+
+.light-button:focus,
+.light-button:hover {
+	border-color: var(--selector-hover-border);
+}
+
+.light-button:active {
+	border-color: var(--selector-active-border);
+}
+
+.selector {
+	display: flex;
+
+	background-color: var(--accent-bg);
+	color: var(--accent-fg);
+}
+
+.selector > button {
+	width: 100%;
+
+	padding: 7px 0 5px 0;
+	border-bottom: 4px solid transparent;
+
+	text-align: center;
+	cursor: pointer;
+}
+
+.selector > button:focus,
+.selector > button:hover {
+	border-color: var(--selector-hover-border);
+}
+
+.selector > button[data-shown],
+.selector > button:active {
+	border-color: var(--selector-active-border);
+}

--- a/public/stylesheets/dialogs.css
+++ b/public/stylesheets/dialogs.css
@@ -56,6 +56,8 @@
 	padding: 0 5px;
 	border: 1px solid transparent;
 	border-radius: 3px;
+
+	cursor: pointer;
 }
 
 .dialog-x:hover {
@@ -157,6 +159,8 @@
 	border-radius: 3px;
 
 	color: var(--header-accent-fg);
+
+	cursor: pointer;
 }
 
 .message-buttons > button:hover {

--- a/public/stylesheets/header.css
+++ b/public/stylesheets/header.css
@@ -73,6 +73,7 @@
 	cursor: pointer;
 }
 
+#selector > button:focus,
 #selector > button:hover {
 	border-color: var(--selector-hover-border);
 }

--- a/public/stylesheets/routes.css
+++ b/public/stylesheets/routes.css
@@ -1,0 +1,63 @@
+#routes-sidebar, #routes-sidebar > div {
+	display: flex;
+	flex-direction: column;
+
+	height: 100%;
+}
+
+#routes-sidebar > :not([data-shown]) {
+	display: none;
+}
+
+#routes-header {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+
+	padding: 5px 25px;
+	border-bottom: 2px solid var(--primary-border);
+}
+
+#routes-search {
+	flex-grow: 1;
+}
+
+/* Webkit browsers add their own ugly search cancel button. Hide it. */
+#routes-search::-webkit-search-cancel-button {
+	display: none;
+}
+
+#dir-lists {
+	display: flex;
+	flex-direction: column;
+
+	overflow-y: auto;
+}
+
+#routes-list,
+#dir-lists > div {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	padding: 4px 7px;
+
+	overflow-y: auto;
+}
+
+#routes-list > button,
+#dir-lists > div > button {
+	text-align: left;
+}
+
+#dir-lists > div:not([data-shown]) {
+	display: none;
+}
+
+#dir-header {
+	padding: 5px;
+}
+
+#dir-chosen {
+	text-align: center;
+}

--- a/public/stylesheets/sidebar.css
+++ b/public/stylesheets/sidebar.css
@@ -1,3 +1,6 @@
+/* Styles each of the relevent tabs on the sidebar. */
+@import "routes.css";
+
 #sidebar {
 	grid-area: 2 / 1 / 3 / 2;
 
@@ -8,109 +11,4 @@
 
 #sidebar > :not([data-shown]) {
 	display: none;
-}
-
-.light-button {
-	padding: 2px 7px;
-	border: 1px solid transparent;
-	border-radius: 3px;
-
-	background-color: var(--accent-bg);
-	color: var(--accent-fg);
-
-	cursor: pointer;
-}
-
-.light-button:hover {
-	border-color: var(--selector-hover-border);
-}
-
-.light-button:active {
-	border-color: var(--selector-active-border);
-}
-
-#routes-sidebar, #routes-sidebar > div {
-	display: flex;
-	flex-direction: column;
-
-	height: 100%;
-}
-
-#routes-sidebar > :not([data-shown]) {
-	display: none;
-}
-
-#routes-loading-box {
-	padding: 5px;
-}
-
-#routes-list-header {
-	padding: 5px;
-	border-bottom: 2px solid var(--primary-border);
-}
-
-#routes-search {
-	margin: 0 20px;
-	width: calc(100% - 40px);
-}
-
-#dir-lists {
-	display: flex;
-	flex-direction: column;
-
-	overflow-y: auto;
-}
-
-#routes-list,
-#dir-lists > div {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-
-	padding: 4px 7px;
-
-	overflow-y: auto;
-}
-
-#routes-list > button,
-#dir-lists > div > button {
-	text-align: left;
-}
-
-#dir-lists > div:not([data-shown]) {
-	display: none;
-}
-
-#dir-header {
-	padding: 5px;
-}
-
-#dir-chosen {
-	text-align: center;
-}
-
-#dir-selector {
-	display: flex;
-
-	background-color: var(--accent-bg);
-	color: var(--accent-fg);
-}
-
-#dir-selector > button {
-	width: 100%;
-
-	padding: 7px 0 5px 0;
-	border-bottom: 4px solid transparent;
-
-	text-align: center;
-	cursor: pointer;
-}
-
-#dir-selector > button:hover {
-	border-color: var(--selector-hover-border);
-}
-
-#dir-selector > button[data-shown],
-#dir-selector > button:active {
-	border-color: var(--selector-active-border);
 }

--- a/public/tests/common.js
+++ b/public/tests/common.js
@@ -3,5 +3,6 @@
 // management.
 exports.testUrls = [
 	"https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js",
+	"javascripts/util.js",
 	"javascripts/fetch.js",
 ];

--- a/public/tests/fetch.test.js
+++ b/public/tests/fetch.test.js
@@ -24,10 +24,10 @@ test("fetchData() can access data and handle errors", async () => {
 	expect(typeof(text)).toBe("string");
 	expect(text[0]).toBe("X");
 
-	await window.fetchText("tests/data/nonExistent.txt")
+	await window.fetchText("tests/data/nonExistent.txt", false)
 		.catch(err => expect(err).toBeDefined());
 
-	await window.fetchText("https://www.example.com")
+	await window.fetchText("https://www.example.com", false)
 		.catch(err => expect(err).toBeDefined());
 });
 
@@ -40,7 +40,7 @@ test("fetchJson() loads JSON correctly", async () => {
 	expect(json.string).toBe("hello world");
 	expect(json.object.key).toBe("value")
 
-	await window.fetchJson("tests/data/testFile.txt")
+	await window.fetchJson("tests/data/testFile.txt", false)
 		.catch(err => expect(err).toBeDefined());
 });
 
@@ -53,6 +53,6 @@ test("fetchXml() loads XML correctly", async () => {
 	expect(xml.documentElement.children.length).toBe(2);
 	expect(xml.documentElement.children[0].getAttribute("attr")).toBe("value");
 
-	await window.fetchJson("tests/data/testFile.txt")
+	await window.fetchXml("tests/data/testFile.txt", false)
 		.catch(err => expect(err).toBeDefined());
 });


### PR DESCRIPTION
So, this is another big PR that refactors a bunch of the code that I wrote in the last PR (note: only my code) because I decided that it was badly thought out.

I know this seems like a lot of code, and I said that I was going to try to write less this sprint.  This is true; however, this PR is mostly fixing things that I goofed up last time due to rushing that PR, particularly fetching.  The rest of the stuff is just minor bugfixes and finishing up minor UI features that I didn't have time to for the last PR.  So, it's really tying up loose ends, not breaking new ground.

* I gave fetching a lot of thought, and now we have a much stronger fetching framework:
    - `fetchData()` and company all automatically retry on failure, no extra code needed elsewhere.
    - I tried making a `Fetcher` class last PR to help things out, but it was overcomplicated and actually not helpful, so I remove it.
    - You can no longer use `fetchData()` the way we previously had it with callbacks; that method just leads to refetching the data every time we need it, and poor TriMet gets flooded with fetches any time we click a button.  The new framework stores the data for future use.
    - It can also fetch the data every few seconds or few minutes in case the data needs updating, like bus locations.
    - I had to make minor changes to the service alerts fetch to get it up to date with this system.  It may look like I changed a lot more code there, but I just decreased the indent of a lot of that code.  Turn of whitespace in diffs in GitHub if you want to ignore the de-indenting.
* Useful message bars that are mostly icing on the cake:
    - We have error message bars at the bottom of the screen if the program is having trouble fetching data.  Disconnect from the Internet to see this.
    - Also try clicking on Service Alerts while the Internet is disconnected and see that it shows a message bar saying that data hasn't loaded yet.  The message bar should also automatically disappear after ten seconds.  The X button should also work.
    - Also see the loading message when data is still loading, which disappears after all initial fetching is done.
* Fixed a number of minor bugs that I had in the last PR.  The table had some scrolling bugs.  Additionally, it's possible for a route to only have _one_ direction instead of two--see the `Portland Streetcar - A/B Loop` for an example--so the code handles this now.